### PR TITLE
Updates "jsdoc" version in "peerDependencies"

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "node": ">=0.6"
   },
   "peerDependencies": {
-    "jsdoc": "3.3.0-alpha2"
+    "jsdoc": "~3.3.0-alpha10"
   }
 }


### PR DESCRIPTION
The "jsdoc" version in "peerDepenecies" causes fail builds using CI (e.g.: Travis CI) with dependency errors, because of the strict versioning (no tilde).
This commit:
- updates the version to the most recent "jsdoc" version (which is "3.3.0-alpha10")
- adds a tilde range for new, future versions

Note: please increase the release/version tag on GitHub after the accepted merge and republish on npm to signal the updates.
Thank you in advance!

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/thlorenz/jsdoc-githubify/2)

<!-- Reviewable:end -->
