### PR TITLE
Bump jsdoc to 3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "node": ">=0.6"
   },
   "peerDependencies": {
-    "jsdoc": "3.3.0-alpha2"
+    "jsdoc": "~3.4.0"
   }
 }


### PR DESCRIPTION
The pinned version here won't install which breaks docme
